### PR TITLE
fix: Pin newer upstream Aptly action

### DIFF
--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           find $(pwd) -name '*.deb'
       - name: Create Aptly repo
-        uses: jinnatar/actions-aptly-repo@v2.0.0
+        uses: jinnatar/actions-aptly-repo@v2.0.2
         with:
           name: kanidm_ppa
           repo_url: https://kanidm.github.io/kanidm_ppa


### PR DESCRIPTION
Bugfix for `kanidm_ppa.list` having the wrong key type, Fixes #6

This is a more targeted fix than #5 which turned out to be more complex.