### PR TITLE
chore: Update stable packages to 1.4.6

### DIFF
--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -24,7 +24,7 @@ jobs:
             ref: 1.3.0
             # While the repo is in "dirty hack" mode, we only publish the latest patch of every minor version.
           - name: stable
-            ref: v1.4.5
+            ref: v1.4.6
           - name: nightly
             ref: master
         os:


### PR DESCRIPTION
As per usual, once action runs seem happy this should be safe to merge.