### PR TITLE
Back out "chore: Update stable packages to 1.4.6"

### DIFF
--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -24,7 +24,7 @@ jobs:
             ref: 1.3.0
             # While the repo is in "dirty hack" mode, we only publish the latest patch of every minor version.
           - name: stable
-            ref: v1.4.6
+            ref: v1.4.5
           - name: nightly
             ref: master
         os:


### PR DESCRIPTION
This backs out commit 2101821b6b7abb41bf1f9d0ae8d6aca46874f56d.

Hopefully mitigates #17 but need to inspect the artifacts closely.