### PR TITLE
Add kanidmd packaging & required structural changes

### DIFF
--- a/scripts/build_debs.sh
+++ b/scripts/build_debs.sh
@@ -88,7 +88,7 @@ echo "Packaging for: ${target}"
 # Build debs per rust package
 metadata_path=$(mktemp)
 cargo metadata --format-version 1 --filter-platform "$target" > "$metadata_path"
-for rust_package in kanidm_unix_int kanidm_tools; do
+for rust_package in daemon kanidm_unix_int kanidm_tools; do
     # Check that we have a config for the package
     manifest_path="$(jq -c ".packages[] | select ( .name == \"$rust_package\" ) | .manifest_path" "$metadata_path" | tr -d \")"
     if [[ "$(grep -c 'package.metadata.deb' "$manifest_path")" != 0 ]]; then

--- a/scripts/build_debs.sh
+++ b/scripts/build_debs.sh
@@ -86,14 +86,31 @@ sed -E \
 
 echo "Packaging for: ${target}"
 # Build debs per rust package
+metadata_path=$(mktemp)
+cargo metadata --format-version 1 --filter-platform "$target" > "$metadata_path"
 for rust_package in kanidm_unix_int kanidm_tools; do
-    echo "Building deb for: ${rust_package}"
-    cargo deb "$VERBOSE" -p "${rust_package}" --no-build --target "$target" --deb-version "$PACKAGE_VERSION"
+    # Check that we have a config for the package
+    manifest_path="$(jq -c ".packages[] | select ( .name == \"$rust_package\" ) | .manifest_path" "$metadata_path" | tr -d \")"
+    if grep 'package.metadata.deb' "$manifest_path" > /dev/null; then
+        echo "Building deb for: ${rust_package}"
+        cargo deb "$VERBOSE" -p "${rust_package}" --no-build --target "$target" --deb-version "$PACKAGE_VERSION"
+    else
+        echo "::warning title=No deb metadata found for ${rust_package}, not building it!:: This may be normal if building an older version."
+    fi
 done
+#TODO: Once variant builds are all gone, these two loops can be combined into one since --multiarch doesn't hurt non-dynlib builds.
 for rust_package in pam_kanidm nss_kanidm; do
-    echo "Building deb for: ${rust_package}"
-# sdynlibs need to use a target specific variant to support multiarch paths
-    cargo deb "$VERBOSE" -p "${rust_package}" --no-build --target "$target" --deb-version "$PACKAGE_VERSION" --multiarch=foreign "$VARIANT"
+    # Check that we have a config for the package
+    manifest_path="$(jq -c ".packages[] | select ( .name == \"$rust_package\" ) | .manifest_path" "$metadata_path" | tr -d \")"
+    if grep 'package.metadata.deb' "$manifest_path" > /dev/null; then
+        echo "Building deb for: ${rust_package}"
+    # sdynlibs need to use a target specific variant to support multiarch paths
+        cargo deb "$VERBOSE" -p "${rust_package}" --no-build --target "$target" --deb-version "$PACKAGE_VERSION" --multiarch=foreign "$VARIANT"
+    else
+        echo "::warning No deb metadata found for ${rust_package}, not building it! This may be normal if building an older version."
+    fi
 done
+rm "$metadata_path"
+
 echo "Target ${target} done, packages:"
 find "target/${target}" -maxdepth 3 -name '*.deb'

--- a/scripts/build_debs.sh
+++ b/scripts/build_debs.sh
@@ -91,7 +91,7 @@ cargo metadata --format-version 1 --filter-platform "$target" > "$metadata_path"
 for rust_package in kanidm_unix_int kanidm_tools; do
     # Check that we have a config for the package
     manifest_path="$(jq -c ".packages[] | select ( .name == \"$rust_package\" ) | .manifest_path" "$metadata_path" | tr -d \")"
-    if grep 'package.metadata.deb' "$manifest_path" > /dev/null; then
+    if [[ "$(grep -c 'package.metadata.deb' "$manifest_path")" != 0 ]]; then
         echo "Building deb for: ${rust_package}"
         cargo deb "$VERBOSE" -p "${rust_package}" --no-build --target "$target" --deb-version "$PACKAGE_VERSION"
     else
@@ -102,7 +102,7 @@ done
 for rust_package in pam_kanidm nss_kanidm; do
     # Check that we have a config for the package
     manifest_path="$(jq -c ".packages[] | select ( .name == \"$rust_package\" ) | .manifest_path" "$metadata_path" | tr -d \")"
-    if grep 'package.metadata.deb' "$manifest_path" > /dev/null; then
+    if [[ "$(grep -c 'package.metadata.deb' "$manifest_path")" != 0 ]]; then
         echo "Building deb for: ${rust_package}"
     # sdynlibs need to use a target specific variant to support multiarch paths
         cargo deb "$VERBOSE" -p "${rust_package}" --no-build --target "$target" --deb-version "$PACKAGE_VERSION" --multiarch=foreign "$VARIANT"

--- a/scripts/build_native.sh
+++ b/scripts/build_native.sh
@@ -36,6 +36,7 @@ cargo build --target "$target" \
   --bin kanidm_ssh_authorizedkeys \
   --bin kanidm-unix \
   --bin kanidm \
+  --bin kanidmd \
   --release
 cargo build --target "$target" \
   -p pam_kanidm \

--- a/scripts/build_native.sh
+++ b/scripts/build_native.sh
@@ -20,8 +20,15 @@ rustup toolchain install stable
 
 . /etc/os-release
 
-echo "Building for: ${target} on ${PRETTY_NAME}"
-export KANIDM_BUILD_PROFILE="release_linux"
+# Where available, we use a dedicated Debian build profile
+if [[ -f libs/profiles/release_debian.toml ]]; then
+    export KANIDM_BUILD_PROFILE="release_debian"
+else
+    export KANIDM_BUILD_PROFILE="release_linux"
+fi
+
+
+echo "Building for: ${target}  with profile ${KANIDM_BUILD_PROFILE} on ${PRETTY_NAME}"
 
 cargo build --target "$target" \
   --bin kanidm_unixd \

--- a/scripts/install_ci_build_dependencies.sh
+++ b/scripts/install_ci_build_dependencies.sh
@@ -48,7 +48,7 @@ fi
 >&2 echo "Installing build dependencies from APT for ${PRETTY_NAME}"
 apt-get update || cat /etc/apt/sources.list.d/ubuntu.sources
 apt-get install -y \
-    curl wget \
+    curl wget jq \
     build-essential pkg-config llvm clang \
     libssl-dev libpam0g-dev libudev-dev \
     "$ssl" "$linker"


### PR DESCRIPTION
While the final commit here is dead simple, the prepwork for it requires two structural changes:
1. Instead of assuming all target refs can provide the same packages, check if we can reasonably assume the package is available.
2. Migrate to a dedicated `release_debian` build profile, since the kanidmd bin bakes in asset paths that can't be configured.
   - This isn't an ideal solution to anything, but so far in discussions it seemed the least disruptive one.

As this all just sets up options to be built when available, runs from this PR are not expected to provide any new artifacts, i.e. the bar to meet in this one is that it still builds everything else as before. A future 1.6.0 / 1.5.1 release change will be the one where we do final packaging testing of kanidmd.

This is part of the puzzle to address https://github.com/kanidm/kanidm/issues/3481