### PR TITLE
feat: Release 1.8.0

### DIFF
--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -20,9 +20,9 @@ jobs:
         category:
           # While the repo is in "dirty hack" mode, we only publish the latest patch of every supported minor version.
           - name: stable
-            ref: v1.6.4
+            ref: v1.7.4
           - name: stable
-            ref: v1.7.3
+            ref: v1.8.0
           - name: nightly
             ref: master
         os:

--- a/README.md
+++ b/README.md
@@ -8,4 +8,81 @@ This repo holds packaging automation that builds debs from `kanidm/kanidm` and f
 - Changes in the public signing key need to be addressed in both `kanidm/kanidm_ppa` & this repo.
 
 For instructions how to use this repo for manual builds, see the book at:
-https://kanidm.github.io/kanidm/stable/packaging/debian_ubuntu_packaging.html
+<https://kanidm.github.io/kanidm/stable/packaging/debian_ubuntu_packaging.html>
+
+## Release process
+
+To cut a new release after upstream releases perform the following steps:
+
+1. Modify `.github/workflows/create-apt-repo.yml`:
+   - Update the matrix category map to bump versions, prefer a tag `ref`.
+    If a new `minor` version has been released,
+    remove the oldest one so only two are always present.
+
+   - Check the matrix os map for any distros where support
+
+    has ended or a new release should already be added.
+    See [Modifying distro support](#modifying-distro-support)
+    for necessary steps.
+
+2. Create a PR:
+   - Commit your changes into a new branch and push to your fork.
+    On GitHub, open a new PR in `Draft` state against the main repo.
+   - Get a project contributor to check your PR and run GitHub Actions
+    for your PR. In the meanwhile you can run them in your fork by either
+    merging to the `main` branch or dispatching the workflow manually.
+
+   - The workflow fanout is large and some steps can fail due to network
+
+    issues. GitHub Actions allows retrying failing steps from the workflow
+    overview which is significantly faster than a full re-run. This may also
+    happen with the final build after merge and needs watching out for.
+
+3. Run conformance testing:
+   - Once GitHub Actions has successfully run through the workflow,
+    open the summary of the workflow run and at the very bottom
+    in the artifacts section you will find a download link for
+    `kanidm_ppa_snapshot.zip`. Download the archive and place it into your
+    working copy as `testing/kanidm_ppa_snapshot.zip`
+
+   - Follow the testing guidance to run through all permutations:
+
+    [Testing procedure](/testing/README.md#testing-procedure). Using
+    the "easy way" guidance with the help of [Mise]() is highly encouraged
+    for the sake of consistency, it's easy to otherwise miss a portion of testing.
+    Please note that you need to repeat the test suite on both
+    x86_64 and arm64. Using real non-emulated hardware is highly encouraged
+    for performance reasons. A native hardware run can easily
+    take 40 minutes, but emulated you'll be at it for hours.
+
+4. Troubleshoot any issues identified during testing, or declare victory:
+   - If any trouble was found, update your PR with details. Issues are usually
+    either across all tests of a version, or isolated to a newer generation
+    of distros.
+
+   - Once all tests pass, mark the PR ready for review.
+5. Once published, install the updated packages on a real system.
+   - You still have a bit of time to quickly fix your mistake if something
+
+    wasn't caught in testing.
+   - Probably a good idea to be vocal about any late found issues in the
+
+    Kanidm community channel, see: [Kanidm Community](https://kanidm.com/community/).
+
+## Modifying distro support
+
+1. In `.github/workflows/create-apt-repo.yml`:
+   - Modify the matrix os map for any distros where support
+    has ended and drop them. Add any replacements and modify
+    the `support` type as needed.`
+
+   - Update the PPA csv data under the `Create Aptly repo` step.
+2. Update the testing harness:
+   - Modify `testing/lib/targets.sh` to remove old distro cloud image
+
+    references and add new ones.
+   - Modify `testing/scripts/run-all.sh` to update the test sets.
+
+    Check the lines starting with `targets=`. There are three sets
+    to potentially modify, the base LTS set, old LTS set and the
+    interim releases set.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For instructions how to use this repo for manual builds, see the book at:
 
 ## Release process
 
-To cut a new release after upstream releases perform the following steps:
+To cut a new release after upstream does, perform the following steps:
 
 1. Modify `.github/workflows/create-apt-repo.yml`:
    - Update the matrix category map to bump versions, prefer a tag `ref`.

--- a/testing/.gitignore
+++ b/testing/.gitignore
@@ -9,3 +9,4 @@
 ssh_ed25519*
 snapshot/*
 !*/.gitkeep
+*.local.toml

--- a/testing/README.md
+++ b/testing/README.md
@@ -6,6 +6,7 @@ What is here was dangerous and repulsive to us. This message is a warning about 
 Testing other architectures is even more Fun than packaging for them. The scripts here make it plausible, if not exactly great.
 
 ## Prerequisites
+
 1. Expect qemu to consume at least 1.2GiB of RAM in the worst case scenario.
 2. Run `scripts/install-deps.sh` to install system level dependencies such as qemu. It assumes Debian, so you may need to substitute as necessary.
 3. Your normal user is assumed to be able to run qemu & KVM. Usually this means belonging to the `kvm` group.
@@ -13,11 +14,13 @@ Testing other architectures is even more Fun than packaging for them. The script
 ## Testing procedure
 
 ### Preamble
+
 1. `cd` to the root of the `testing/` dir.
 1. Download a GHA repo snapshot artifact zip and place it in the current directory as `kanidm_ppa_snapshot.zip`. Or, check the settings
    further down to test in other ways without a snapshot.
 
 ### Running the standard comformance test set the easy way
+
 Mise is used to run a standardized set of 24 test permutations.
 For the full test, repeat it on all supported architectures.
 Time taken will vary by system performance and how quickly you notice the
@@ -36,6 +39,7 @@ to multitasking is around 40 minutes.
    above and the next one is launching, repeat the process.
 
 ### Running arbitrary tests the hard way without Mise
+
 1. Run `IDM_URI=https://idm.example.com scripts/run-all.sh`, you may want to override other bits of env, see the bottom of this README.
    - At first your snapshot is unpacked and a mirror is launched with the contents listening on localhost.
    - You can view what's going on in the console of the qemu VM with `nc localhost 4321`, this is only necessary if something goes horribly wrong.
@@ -44,20 +48,25 @@ to multitasking is around 40 minutes.
    If anything goes wrong, execution will pause instead with a warning to allow investigation.
 1. Testing time.
    - A good basic test is to run in another terminal:
+
    ```shell
    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     localhost -p 2222 \
     "uname -a && cat /etc/os-release && kanidm login -D anonymous && kanidm self whoami"
    ```
+
    - Or if that doesn't work, troubleshoot via the cloud-init injected root key:
+
    ```shell
    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -i ssh_ed25519 root@localhost -p 2222
    ```
+
 1. Once  happy with the permutation, hit `^C` in the original terminal to terminate the permutation. Hit `Enter` to continue to the next one.
 1. Iterate until your willpower has crumbled or you reach the end of the target list.
 
 ### Known issues
+
 - aarch64 is super slow cross-arch, so we disable cross-arch by default. Instead, run the same testing natively on an aarch64 platform and it'll work ok.
 - We throw 4 cores for the cpu so that mounting the rootfs is fast enough to not time out on ubuntu. Yes, that's a crazy problem to have.
 - If you insist in running aarch64 cross-arch, beware that systemd will throw weird hissyfits. The arguments try to work around it, but it's not foolproof.
@@ -65,11 +74,13 @@ to multitasking is around 40 minutes.
   This makes GPT unhappy, but that seems to be ok.
 
 ### Config tweaks
+
 You can set various environment variables to change testing behavior, either to suit your environment, or to test different things.
 For example, `USE_DEBDIR` can be very helpful in rapid testing of packaging & code changes without waiting for a full snapshot
 build from GHA, though less valuable for proving the PPA itself will be functional.
 
 #### Testing different things
+
 - `CATEGORY` - Which mirror category to install, `stable` (default) or `nightly`.
 - `KANIDM_VERSION` - Version prefix to install from the category. `1.4` would install the latest available 1.4, say 1.4.6. The default is latest.
 - `USE_LIVE` - Use the live Kanidm PPA mirror instead of a local snapshot. Default is `false`.
@@ -81,6 +92,7 @@ packages from the dir given with this option.
   warnings.
 
 #### Settings for your environment
+
 - `IDM_URI` - Change which live kanidm server is used. Your user is expected to have SSH & posix enabled on this server.
   Set to `local` to spin up kanidmd within the VM and use that. This is not yet supported in all versions.
 - `IDM_GROUP` - A posix enabled group on the above server to gate unixd authentication.
@@ -88,6 +100,7 @@ packages from the dir given with this option.
 - `SSH_PUBLICKEY` - Only relevant if `IDM_URI=local`. The public key to enable for SSH login.
 
 #### Port settings
+
 All ports are bound only on localhost, so should normally not interfere with other activity.
 
 - `MIRROR_PORT` - 31625 - Port to use for the snapshot mirror httpd.

--- a/testing/README.md
+++ b/testing/README.md
@@ -12,9 +12,30 @@ Testing other architectures is even more Fun than packaging for them. The script
 
 ## Testing procedure
 
+### Preamble
 1. `cd` to the root of the `testing/` dir.
 1. Download a GHA repo snapshot artifact zip and place it in the current directory as `kanidm_ppa_snapshot.zip`. Or, check the settings
    further down to test in other ways without a snapshot.
+
+### Running the standard comformance test set the easy way
+Mise is used to run a standardized set of 24 test permutations.
+For the full test, repeat it on all supported architectures.
+Time taken will vary by system performance and how quickly you notice the
+next permutation is up for test. A typical example for the author
+if all cloud images are already cached and ample latency is factored in due
+to multitasking is around 40 minutes.
+
+1. Install Mise following these instructions: [Mise-en-place Getting Started](https://mise.jdx.dev/getting-started.html).
+1. Copy `mise.local.toml.example` to `mise.local.toml` and configure `IDM_URI` & `SSH_PUBLICKEY`.
+   They are explained better further down,
+1. Launch the full test run: `mise run test_all` (Use `mise run` to see available modules.)
+1. Wait for the test payload to finish setup, once it's tailing Kanidm debug logs it's ready.
+1. In another terminal, launch the test sript: `mise run test_now && kill $(pgrep -f StrictHostKeyChecking)`
+1. Either debug what went wrong with `mise run debug`,
+   or if all was fine the permutation was already killed by the example
+   above and the next one is launching, repeat the process.
+
+### Running arbitrary tests the hard way without Mise
 1. Run `IDM_URI=https://idm.example.com scripts/run-all.sh`, you may want to override other bits of env, see the bottom of this README.
    - At first your snapshot is unpacked and a mirror is launched with the contents listening on localhost.
    - You can view what's going on in the console of the qemu VM with `nc localhost 4321`, this is only necessary if something goes horribly wrong.

--- a/testing/README.md
+++ b/testing/README.md
@@ -21,7 +21,7 @@ Testing other architectures is even more Fun than packaging for them. The script
 
 ### Running the standard comformance test set the easy way
 
-Mise is used to run a standardized set of 24 test permutations.
+[Mise](https://mise.jdx.dev) is used to run a standardized set of 24 test permutations.
 For the full test, repeat it on all supported architectures.
 Time taken will vary by system performance and how quickly you notice the
 next permutation is up for test. A typical example for the author

--- a/testing/mise.local.toml.example
+++ b/testing/mise.local.toml.example
@@ -1,0 +1,7 @@
+[env]
+# Make a copy of this file to mise.local.toml
+# and then set these variables:
+
+IDM_URI = "https://idm.example.com"
+SSH_PUBLICKEY = "ssh-ed25519 AAAAfoobarbaz you@localhost"
+#IDM_GROUP = "posix_login"

--- a/testing/mise.toml
+++ b/testing/mise.toml
@@ -1,0 +1,56 @@
+[env]
+IDM_URI = { required = "copy mise.local.toml.example to mise.local.toml and configure it" }
+SSH_PUBLICKEY = { required = "copy mise.local.toml.example to mise.local.toml and configure it" }
+
+[settings]
+jobs = 1
+
+[tasks.test_all]
+depends = ["test:*"]
+
+[tasks.test_now]
+run = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null localhost -p 2222 "uname -a && cat /etc/os-release && kanidm login -D anonymous && kanidm self whoami && kanidm version"'
+
+[tasks.debug]
+run = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@localhost -p 2222 -i ssh_ed25519'
+
+[tasks."test:stable:ext"]
+run = "scripts/run-all.sh"
+[tasks."test:stable:ext".env]
+SUCCESS_WAIT = "false"
+CATEGORY = "stable"
+
+[tasks."test:stable:self"]
+run = "scripts/run-all.sh"
+[tasks."test:stable:self".env]
+SUCCESS_WAIT = "false"
+CATEGORY = "stable"
+IDM_URI = "local"
+
+[tasks."test:nightly:ext"]
+run = "scripts/run-all.sh"
+[tasks."test:nightly:ext".env]
+SUCCESS_WAIT = "false"
+CATEGORY = "nightly"
+
+[tasks."test:nightly:self"]
+run = "scripts/run-all.sh"
+[tasks."test:nightly:self".env]
+SUCCESS_WAIT = "false"
+CATEGORY = "nightly"
+IDM_URI = "local"
+
+[tasks."test:oldstable:ext"]
+run = "scripts/run-all.sh"
+[tasks."test:oldstable:ext".env]
+SUCCESS_WAIT = "false"
+CATEGORY = "stable"
+KANIDM_VERSION = "1.7"
+
+[tasks."test:oldstable:self"]
+run = "scripts/run-all.sh"
+[tasks."test:oldstable:self".env]
+SUCCESS_WAIT = "false"
+CATEGORY = "stable"
+KANIDM_VERSION = "1.7"
+IDM_URI = "local"

--- a/testing/scripts/run-all.sh
+++ b/testing/scripts/run-all.sh
@@ -20,6 +20,7 @@ export OSARCH="${OSARCH:-$(dpkg --print-architecture)}"  # cross-arch is in no w
 export CPUARCH="${CPUARCH:-$(uname -m)}"  # But if you insist, override both
 TEST_TARGETS="${TEST_TARGETS:-}"  # Single string space separated which targets to run. Default runs all
 export PRETEND_TARGET="${PRETEND_TARGET:-false}"  # Force all TEST_TARGETS to install packages from this target
+SUCCESS_WAIT="${SUCCESS_WAIT:-true}"  # Ask for confirmation before continuing to the next test after a success
 TEST_ROOT="$(readlink -f "$(dirname "$0")"/..)"
 
 if [[ "$IDM_URI" == "local" ]] && [[ "$SSH_PUBLICKEY" == "none" ]]; then
@@ -56,7 +57,7 @@ function prompt(){
 function run(){
 	distro="$1"
 	scripts/launch-one.sh "$CPUARCH" "images/$(basename "${!distro}")"  || exit 1
-	prompt
+	[[ "$SUCCESS_WAIT" == "true" ]] && prompt
 	sleep 2s  # Wait for qemu to release ports
 }
 
@@ -134,3 +135,4 @@ log "$GREEN" "Done with all targets"
 
 set +e  # Allow cleanup to fail
 cleanup || exit 0
+exit 0


### PR DESCRIPTION
Also bump 1.7 to 1.7.4, which should make no difference in terms of content given it's purely a build system maintenance release.

I've also wrapped the testing framework with Mise to make it significantly easier, repeatable and faster to run the "standard" set of conformance tests I've been doing.