### PR TITLE
feat: Release 1.9.2

### DIFF
--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -22,7 +22,7 @@ jobs:
           - name: stable
             ref: v1.8.6
           - name: stable
-            ref: v1.9.1
+            ref: v1.9.2
           - name: nightly
             ref: master
         os:

--- a/testing/mise.toml
+++ b/testing/mise.toml
@@ -29,7 +29,7 @@ run = '''
   ssh -o StrictHostKeyChecking=no \
       -o UserKnownHostsFile=/dev/null \
       -o LogLevel=ERROR \
-      localhost -p 2222
+      localhost -p ${SSH_PORT:-2222}
   '''
 
 [tasks.test_now]
@@ -40,7 +40,7 @@ run = '''
       -o LogLevel=ERROR \
       -o PasswordAuthentication=no \
       -o BatchMode=yes \
-      localhost -p 2222 \
+      localhost -p ${SSH_PORT:-2222} \
     "source /etc/test_env && \
     source /etc/os-release && \
     echo \"TEST_ID=\${TEST_ID}\" && \
@@ -55,7 +55,7 @@ description = "Connect to a running test as root bypassing Kanidm auth"
 run = '''
   ssh -o StrictHostKeyChecking=no \
       -o UserKnownHostsFile=/dev/null \
-      root@localhost -p 2222 -i ssh_ed25519
+      root@localhost -p ${SSH_PORT:-2222} -i ssh_ed25519
 '''
 
 # Test cases begin


### PR DESCRIPTION
Release 1.9.2

Also:
- Minor fix to testing for SSH port handling in mise helpers

### Test results

- Tests flagged as `ext` are against an external container run current stable kanidmd.
- Tests flagged as `self` are against an internal PPA installed kanidmd of the same version.
- Distro targets for `stable`: `trixie noble bookworm jammy questing`
- Distro targets for `nightly`: `trixie noble`

| TEST_ID                            | x86_64                  | aarch64                 |
| ---------------------------------- | ----------------------- | ----------------------- |
| testcase:1e:stable:ext             | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:1s:stable:self            | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2e:oldstable-upgrade:ext  | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2s:oldstable-upgrade:self | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:3e:nightly:ext            | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:4e:oldstable:ext          | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:4s:oldstable:self         | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |