### PR TITLE
feat: Release 1.9.3, yank 1.8.x

### DIFF
--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -19,10 +19,11 @@ jobs:
       matrix:
         category:
           # While the repo is in "dirty hack" mode, we only publish the latest patch of every supported minor version.
+          # 1.8.x yanked as vulnerable, see: https://github.com/kanidm/kanidm/issues/4303
+          # - name: stable
+          #   ref: v1.8.6
           - name: stable
-            ref: v1.8.6
-          - name: stable
-            ref: v1.9.2
+            ref: v1.9.3
           - name: nightly
             ref: master
         os:


### PR DESCRIPTION
For details on the yank, see: https://github.com/kanidm/kanidm/issues/4303

### Test results

- Tests flagged as `ext` are against an external container run current stable kanidmd.
- Tests flagged as `self` are against an internal PPA installed kanidmd of the same version.
- Distro targets for `stable`: `trixie noble bookworm jammy questing`
- Distro targets for `nightly`: `trixie noble`

Some cases will be missing from testing this time as they've been skipped due to missing packages (the yank) or to speed up release of the important bits. (nightly)

| TEST_ID                            | x86_64                  | aarch64                 |
| ---------------------------------- | ----------------------- | ----------------------- |
| testcase:1e:stable:ext             | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:1s:stable:self            | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2e:oldstable-upgrade:ext  | <ul><li> [ ] </li></ul> | <ul><li> [ ] </li></ul> |
| testcase:2s:oldstable-upgrade:self | <ul><li> [ ] </li></ul> | <ul><li> [ ] </li></ul> |
| testcase:3e:nightly:ext            | <ul><li> [ ] </li></ul> | <ul><li> [ ] </li></ul> |
| testcase:4e:oldstable:ext          | <ul><li> [ ] </li></ul> | <ul><li> [ ] </li></ul> |
| testcase:4s:oldstable:self         | <ul><li> [ ] </li></ul> | <ul><li> [ ] </li></ul> |