### PR TITLE
Release 1.10.2 & 1.9.4, add support for Ubuntu 26.04 Resolute Raccoon

### DIFF
--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -103,16 +103,6 @@ jobs:
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444
         with:
           mold-version: 2.41.0
-      - name: Configure sccache
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-        with:
-          version: "v0.15.0"
       # Step 1. Build
       - name: Build packages (bins & libs)
         shell: bash
@@ -121,8 +111,6 @@ jobs:
             "${{ matrix.target.name }}"
         env:
           VERBOSE: true
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
           RUSTFLAGS: "-Clinker=clang -Clink-arg=-fuse-ld=/usr/local/bin/mold"
       # Step 1.5. Strip binaries
       # This significantly helps with storage limits.

--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -38,10 +38,13 @@ jobs:
             support: old-LTS # 2027, April
           - name: noble
             image: ubuntu:24.04
-            support: LTS # 2029, April
+            support: old-LTS # 2029, May
           - name: questing
             image: ubuntu:25.10
             support: interim # 2026, July
+          - name: resolute
+            image: ubuntu:26.04
+            support: LTS # 2031, May
         target:
           # Runner postfixes add to "ubuntu-24.04"
           - name: x86_64-unknown-linux-gnu
@@ -157,8 +160,9 @@ jobs:
             jammy,stable,\"amd64,arm64\",false,debs/stable-*-jammy-*-unknown-linux-gnu/*.deb
             noble,stable,\"amd64,arm64\",false,debs/stable-*-noble-*-unknown-linux-gnu/*.deb
             questing,stable,\"amd64,arm64\",false,debs/stable-*-questing-*-unknown-linux-gnu/*.deb
+            resolute,stable,\"amd64,arm64\",false,debs/stable-*-resolute-*-unknown-linux-gnu/*.deb
             trixie,nightly,\"amd64,arm64\",false,debs/nightly-master-trixie-*-unknown-linux-gnu/*.deb
-            noble,nightly,\"amd64,arm64\",false,debs/nightly-master-noble-*-unknown-linux-gnu/*.deb
+            resolute,nightly,\"amd64,arm64\",false,debs/nightly-master-resolute-*-unknown-linux-gnu/*.deb
           # When GPG secrets are not available (say a PR), the repo WILL NOT be signed.
           # Provide your own key material in a fork to test with signed repo snapshots.
           gpg_private_key: "${{ secrets.GPG_PRIVATE_KEY }}"

--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -1,13 +1,11 @@
 ---
 name: "Create apt repo"
-
 "on": # TODO: This needs to also become a cron for the nightly function to make sense
   push:
     branches:
       - main
   pull_request:
   workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -52,13 +50,13 @@ jobs:
           - name: aarch64-unknown-linux-gnu
             runner-postfix: "-arm"
         exclude: # Nightlies are only for latest LTS versions, exclude old-LTS & interim
-          - category: { name: nightly }
-            os: { support: old-LTS }
-          - category: { name: nightly }
-            os: { support: interim }
-
+          - category: {name: nightly}
+            os: {support: old-LTS}
+          - category: {name: nightly}
+            os: {support: interim}
     runs-on: "ubuntu-24.04${{ matrix.target.runner-postfix }}"
-    container: "${{ matrix.os.image }}"
+    container:
+      image: "${{ matrix.os.image }}"
     steps:
       # Needed because we're not running directly on the runner,
       # and if we checkout before having git, it's done through the REST API and missing .git
@@ -67,14 +65,14 @@ jobs:
         run: apt update && apt install -y git
       # Step 0. Pick up the stable or nightly source
       - name: Checkout Kanidm
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "kanidm/kanidm"
           ref: "${{ matrix.category.ref }}"
           submodules: false
       # Overlay the latest packaging tools instead of using the submodule reference which is intended for human use.
       - name: Checkout packaging tools
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: platform/debian/kanidm_ppa_automation
       # Step 0.5. Get a bunch of dependencies
@@ -88,7 +86,7 @@ jobs:
           echo "RUST_VERSION=$(awk -F \" '/^rust-version/ {print $2}' Cargo.toml)" >> $GITHUB_ENV
       # We need to grab Rust manually since we're on vanilla images, not GHA runners
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.71
+        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100
         with:
           toolchain: $RUST_VERSION
       - name: Setup mold
@@ -96,13 +94,13 @@ jobs:
         with:
           mold-version: 2.41.0
       - name: Configure sccache
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         with:
           version: "v0.15.0"
       # Step 1. Build
@@ -128,14 +126,12 @@ jobs:
       - name: Build packages (debs)
         run: |
           platform/debian/kanidm_ppa_automation/scripts/build_debs.sh "${{ matrix.target.name }}"
-
       - name: Upload debs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "${{matrix.category.name}}-${{matrix.category.ref}}-${{ matrix.os.name }}-${{ matrix.target.name }}"
           path: |
             target/${{ matrix.target.name }}/debian/*.deb
-
   # Step 3. Create the APT repo from the debs
   create-repo:
     name: Create APT repo
@@ -143,7 +139,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download previously built debs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: debs
           merge-multiple: false # Preserve which debs are from which matrix item
@@ -151,7 +147,7 @@ jobs:
         run: |
           find $(pwd) -name '*.deb'
       - name: Create Aptly repo
-        uses: jinnatar/actions-aptly-repo@v2.0.2
+        uses: jinnatar/actions-aptly-repo@e88155fae696e037dc0d3fa3325d30fd7270e620 # v2.0.2
         with:
           name: kanidm_ppa
           repo_url: https://kanidm.github.io/kanidm_ppa
@@ -171,7 +167,6 @@ jobs:
           # Provide your own key material in a fork to test with signed repo snapshots.
           gpg_private_key: "${{ secrets.GPG_PRIVATE_KEY }}"
           gpg_passphrase: "${{ secrets.PASSPHRASE }}"
-
   # Step 4. Publish the created repo if and only if it's a push to main.
   publish:
     name: Deploy to GitHub Pages
@@ -179,7 +174,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download repo snapshot
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: kanidm_ppa_snapshot
           path: snapshot
@@ -189,7 +184,7 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/kanidm/kanidm/refs/heads/master/book/src/packaging/ppa_packages.md > snapshot/README.md
       - name: Import GPG key # So we can sign the repository commit
-        uses: crazy-max/ghaction-import-gpg@v7.0.0
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         env:
           # GitHub is a real ass about checking whether secrets are available or not.
           private_key_check: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -199,7 +194,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
           git_commit_gpgsign: true
       - name: Publish to PPA
-        uses: crazy-max/ghaction-github-pages@v5.0.0
+        uses: crazy-max/ghaction-github-pages@1d6ee9b181a81033a16bd707a1401afa978daab4 # v5.0.0
         if: github.ref == 'refs/heads/main'
         with:
           repo: kanidm/kanidm_ppa

--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -19,11 +19,10 @@ jobs:
       matrix:
         category:
           # While the repo is in "dirty hack" mode, we only publish the latest patch of every supported minor version.
-          # 1.8.x yanked as vulnerable, see: https://github.com/kanidm/kanidm/issues/4303
-          # - name: stable
-          #   ref: v1.8.6
           - name: stable
             ref: v1.9.3
+          - name: stable
+            ref: v1.10.0
           - name: nightly
             ref: master
         os:

--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -18,9 +18,9 @@ jobs:
         category:
           # While the repo is in "dirty hack" mode, we only publish the latest patch of every supported minor version.
           - name: stable
-            ref: v1.9.3
+            ref: v1.9.4
           - name: stable
-            ref: v1.10.1
+            ref: v1.10.2
           - name: nightly
             ref: master
         os:

--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -62,7 +62,7 @@ jobs:
       # and if we checkout before having git, it's done through the REST API and missing .git
       - name: Get git
         shell: bash
-        run: apt update && apt install -y git
+        run: apt-get update && apt-get install -y git
       # Step 0. Pick up the stable or nightly source
       - name: Checkout Kanidm
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -86,9 +86,19 @@ jobs:
           echo "RUST_VERSION=$(awk -F \" '/^rust-version/ {print $2}' Cargo.toml)" >> $GITHUB_ENV
       # We need to grab Rust manually since we're on vanilla images, not GHA runners
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4a76a4951e2b37e999824e644cd130c67037ee2b # 1.100
-        with:
-          toolchain: $RUST_VERSION
+        shell: bash
+        # While rustlang does not have an official action (they are working on one) we unfortunately need to rely
+        # on rustup.rs, which all the unofficial ones rely on anyway under the hood.
+        # Due to this they are also under a constant effective DDoS so generous and patient retrying is better than
+        # failing the entire shard. The curl retry logic starts with a 1s delay and doubles it up every iteration up to a
+        # max of 10 minutes per retry, so the total possible runtime here is ~27 minutes, or roughly doubling the total
+        # runtime from an ideal scenario.
+        # We also need to retry all errors as transient as the GHA environment causes some temporary issues to look
+        # like permanents and even a --retry-connrefused isn't enough to catch all of them.
+        run: |
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-all-errors -fsSL \
+            "https://sh.rustup.rs" | sh -s -- --default-toolchain $RUST_VERSION -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444
         with:

--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -20,7 +20,7 @@ jobs:
           - name: stable
             ref: v1.9.3
           - name: stable
-            ref: v1.10.0
+            ref: v1.10.1
           - name: nightly
             ref: master
         os:

--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -67,14 +67,14 @@ jobs:
         run: apt update && apt install -y git
       # Step 0. Pick up the stable or nightly source
       - name: Checkout Kanidm
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "kanidm/kanidm"
           ref: "${{ matrix.category.ref }}"
           submodules: false
       # Overlay the latest packaging tools instead of using the submodule reference which is intended for human use.
       - name: Checkout packaging tools
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: platform/debian/kanidm_ppa_automation
       # Step 0.5. Get a bunch of dependencies
@@ -88,19 +88,23 @@ jobs:
           echo "RUST_VERSION=$(awk -F \" '/^rust-version/ {print $2}' Cargo.toml)" >> $GITHUB_ENV
       # We need to grab Rust manually since we're on vanilla images, not GHA runners
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@1.71
         with:
           toolchain: $RUST_VERSION
       - name: Setup mold
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444
+        with:
+          mold-version: 2.41.0
       - name: Configure sccache
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: "v0.15.0"
       # Step 1. Build
       - name: Build packages (bins & libs)
         shell: bash
@@ -126,7 +130,7 @@ jobs:
           platform/debian/kanidm_ppa_automation/scripts/build_debs.sh "${{ matrix.target.name }}"
 
       - name: Upload debs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "${{matrix.category.name}}-${{matrix.category.ref}}-${{ matrix.os.name }}-${{ matrix.target.name }}"
           path: |
@@ -139,7 +143,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download previously built debs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: debs
           merge-multiple: false # Preserve which debs are from which matrix item
@@ -175,7 +179,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download repo snapshot
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: kanidm_ppa_snapshot
           path: snapshot
@@ -185,7 +189,7 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/kanidm/kanidm/refs/heads/master/book/src/packaging/ppa_packages.md > snapshot/README.md
       - name: Import GPG key # So we can sign the repository commit
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7.0.0
         env:
           # GitHub is a real ass about checking whether secrets are available or not.
           private_key_check: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -195,7 +199,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
           git_commit_gpgsign: true
       - name: Publish to PPA
-        uses: crazy-max/ghaction-github-pages@v4
+        uses: crazy-max/ghaction-github-pages@v5.0.0
         if: github.ref == 'refs/heads/main'
         with:
           repo: kanidm/kanidm_ppa

--- a/README.md
+++ b/README.md
@@ -77,3 +77,22 @@ To cut a new release after upstream does, perform the following steps:
      Check the lines starting with `targets=`. There are three sets
      to potentially modify, the base LTS set, old LTS set and the
      interim releases set.
+
+## Other maintenance tasks
+
+We rely on a handful of external "non-official" Github Actions for the release CI.
+They may occasionally require updates, but due to the general state of supply chain security
+we want to be deliberate about updates. To facilitate this the repo contains a still overly
+simple [updatecli](https://www.updatecli.io/) config which allows locally bumping versions
+and tying them to current latest release hashes. Any bumping should be accompanied by a cursory
+review of what's changed, but that may at times be quite hard due to the use of js minification.
+Do your best.
+
+Example dependency update invocation:
+```shell
+GITHUB_TOKEN="$(gh auth token)" updatecli pipeline apply
+```
+
+- The changes will be done in your currently checked out copy which allows local diffing & manual commit.
+- Ignore the warnings caused by the matrix sharding, ideally these would somehow be skipped or silenced
+since it's a false positive due to our use of vanilla images.

--- a/testing/lib/targets.sh
+++ b/testing/lib/targets.sh
@@ -9,3 +9,4 @@ bookworm="https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generi
 noble="https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-${OSARCH}.img"
 jammy="https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-${OSARCH}.img"
 questing="https://cloud-images.ubuntu.com/questing/current/questing-server-cloudimg-${OSARCH}.img"
+resolute="https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-${OSARCH}.img"

--- a/testing/scripts/run-all.sh
+++ b/testing/scripts/run-all.sh
@@ -12,20 +12,20 @@ TELNET_PORT="${TELNET_PORT:-4321}"
 export SERIAL_CONFIG="${SERIAL_CONFIG:-telnet:localhost:${TELNET_PORT},server,nowait}" # Useful to override for debugging obscure qemu issues
 export CATEGORY="${CATEGORY:-stable}"
 export USE_LIVE="${USE_LIVE:-false}"
-export USE_DEBDIR="${USE_DEBDIR:-false}"  # If not false, expected to be a directory
-export KANIDM_VERSION="${KANIDM_VERSION:-*}"  # * default picks latest
-export KANIDM_UPGRADE="${KANIDM_UPGRADE:-false}"  # To test upgrades: set KANIDM_VERSION to an old version and this to true
+export USE_DEBDIR="${USE_DEBDIR:-false}"         # If not false, expected to be a directory
+export KANIDM_VERSION="${KANIDM_VERSION:-*}"     # * default picks latest
+export KANIDM_UPGRADE="${KANIDM_UPGRADE:-false}" # To test upgrades: set KANIDM_VERSION to an old version and this to true
 export IDM_USER="${IDM_USER:-$USER}"
-export IDM_PORT="${IDM_PORT:-58915}"  # Only relevant if IDM_URI=local
-export SSH_PUBLICKEY="${SSH_PUBLICKEY:-none}"  # Only relevant if IDM_URI=local
-export ALLOW_UNSIGNED="${ALLOW_UNSIGNED:-true}"  # Only relevant if USE_LIVE=false
-export OSARCH="${OSARCH:-$(dpkg --print-architecture)}"  # cross-arch is in no way guaranteed to work
-export CPUARCH="${CPUARCH:-$(uname -m)}"  # But if you insist, override both
-TEST_TARGETS="${TEST_TARGETS:-}"  # Single string space separated which targets to run. Default runs all
-export PRETEND_TARGET="${PRETEND_TARGET:-false}"  # Force all TEST_TARGETS to install packages from this target
-SUCCESS_WAIT="${SUCCESS_WAIT:-true}"  # Ask for confirmation before continuing to the next test after a success
+export IDM_PORT="${IDM_PORT:-58915}"                    # Only relevant if IDM_URI=local
+export SSH_PUBLICKEY="${SSH_PUBLICKEY:-none}"           # Only relevant if IDM_URI=local
+export ALLOW_UNSIGNED="${ALLOW_UNSIGNED:-true}"         # Only relevant if USE_LIVE=false
+export OSARCH="${OSARCH:-$(dpkg --print-architecture)}" # cross-arch is in no way guaranteed to work
+export CPUARCH="${CPUARCH:-$(uname -m)}"                # But if you insist, override both
+TEST_TARGETS="${TEST_TARGETS:-}"                        # Single string space separated which targets to run. Default runs all
+export PRETEND_TARGET="${PRETEND_TARGET:-false}"        # Force all TEST_TARGETS to install packages from this target
+SUCCESS_WAIT="${SUCCESS_WAIT:-true}"                    # Ask for confirmation before continuing to the next test after a success
 TEST_ROOT="$(readlink -f "$(dirname "$0")"/..)"
-export MISE_TASK_NAME="${MISE_TASK_NAME:-custom}"  # Set by Mise when running defined test sets
+export MISE_TASK_NAME="${MISE_TASK_NAME:-custom}" # Set by Mise when running defined test sets
 
 if [[ "$IDM_URI" == "local" ]] && [[ "$SSH_PUBLICKEY" == "none" ]]; then
   >&2 echo "SSH_PUBLICKEY must be set for IDM_URI=local"
@@ -42,51 +42,49 @@ source lib/log.sh
 # shellcheck source=../lib/targets.sh
 source lib/targets.sh
 
-function cleanup(){
+function cleanup() {
   set +e
   >&2 echo "Killing background processes..."
   rm -fr snapshot/*
-  sleep 2  # Give a bit of time for any proper shutdown that may work
-  [[ -f mirror.pid ]] && kill "$(cat mirror.pid)" ; ( rm mirror.pid 2>/dev/null )
-  [[ -f qemu.pid ]]   && kill "$(cat qemu.pid)"   ; ( rm qemu.pid 2>/dev/null )
+  sleep 2 # Give a bit of time for any proper shutdown that may work
+  [[ -f mirror.pid ]] && kill "$(cat mirror.pid)"
+  (rm mirror.pid 2>/dev/null)
+  [[ -f qemu.pid ]] && kill "$(cat qemu.pid)"
+  (rm qemu.pid 2>/dev/null)
 }
 
-
-function prompt(){
+function prompt() {
   read -rp "Happy? ^C to stop full run, enter to continue to next target."
 }
 
-
-
-function run(){
-	distro="$1"
-	scripts/launch-one.sh "$CPUARCH" "images/$(basename "${!distro}")"  || exit 1
-	[[ "$SUCCESS_WAIT" == "true" ]] && prompt
-	sleep 2s  # Wait for qemu to release ports
+function run() {
+  distro="$1"
+  scripts/launch-one.sh "$CPUARCH" "images/$(basename "${!distro}")" || exit 1
+  [[ "$SUCCESS_WAIT" == "true" ]] && prompt
+  sleep 2s # Wait for qemu to release ports
 }
 
-
-function get_images(){
+function get_images() {
   targets=("$@")
   mkdir -p images
 
   # Expand targets to images
   images=()
   for target in "${targets[@]}"; do
-          images+=("${!target}")
+    images+=("${!target}")
   done
 
   # Download & prep all requested target images
   log "$GREEN" "Preloading any missing target images"
   for url in "${images[@]}"; do
-          file="$(basename "$url")"
-          if [[ ! -f "images/${file}" ]]; then
-                  wget "$url" -O "images/${file}"
-                  log "$GREEN" "Resizing $file so the dpkg operations & debug binaries will fit"
-                  # The bump is quite big as the worst case scenario has ~100MiB empty after
-                  # debug deb installs even with this size. This does not increase the on-disk size.
-                  qemu-img resize "images/${file}" +1.5G  
-          fi
+    file="$(basename "$url")"
+    if [[ ! -f "images/${file}" ]]; then
+      wget "$url" -O "images/${file}"
+      log "$GREEN" "Resizing $file so the dpkg operations & debug binaries will fit"
+      # The bump is quite big as the worst case scenario has ~100MiB empty after
+      # debug deb installs even with this size. This does not increase the on-disk size.
+      qemu-img resize "images/${file}" +1.5G
+    fi
   done
 }
 
@@ -94,7 +92,7 @@ function get_images(){
 
 # If we already have a target list, use it as-is
 if [[ -n "$TEST_TARGETS" ]]; then
-  IFS=" " read -r -a targets <<< "$TEST_TARGETS"
+  IFS=" " read -r -a targets <<<"$TEST_TARGETS"
 else
   # Base set of targets: Latest LTS releases
   targets=(trixie noble)
@@ -119,7 +117,7 @@ if [[ "$USE_LIVE" == "false" && "$USE_DEBDIR" == "false" ]]; then
     exit 1
   fi
   scripts/run-mirror.sh kanidm_ppa_snapshot.zip &
-  sleep 2s  # A bit of time for the unzip before we try to use the mirror
+  sleep 2s # A bit of time for the unzip before we try to use the mirror
 fi
 
 modestring="mirror snapshot, version: ${KANIDM_VERSION}/${CATEGORY}"
@@ -140,6 +138,6 @@ for target in "${targets[@]}"; do
 done
 log "$GREEN" "Done with all targets"
 
-set +e  # Allow cleanup to fail
+set +e # Allow cleanup to fail
 cleanup || exit 0
 exit 0

--- a/testing/scripts/run-all.sh
+++ b/testing/scripts/run-all.sh
@@ -95,11 +95,11 @@ if [[ -n "$TEST_TARGETS" ]]; then
   IFS=" " read -r -a targets <<<"$TEST_TARGETS"
 else
   # Base set of targets: Latest LTS releases
-  targets=(trixie noble)
+  targets=(trixie resolute)
   # Additional targets won't work for nightly
   if [[ "$CATEGORY" != "nightly" ]]; then
     # Previous still supported LTS
-    targets+=(bookworm jammy)
+    targets+=(bookworm noble jammy)
     # Interim releases
     targets+=(questing)
   fi

--- a/testing/test_payload.sh
+++ b/testing/test_payload.sh
@@ -216,9 +216,6 @@ for service in kanidm-unixd kanidm-unixd-tasks; do
   mkdir -p "/etc/systemd/system/${service}.service.d"
   cat << EOF > "/etc/systemd/system/${service}.service.d/env.conf"
 [Service]
-# Needed for =< 1.5
-Environment="KANIDM_DEBUG=true"
-# Works for >= 1.6
 Environment="RUST_LOG=kanidm=debug"
 EOF
 done
@@ -265,14 +262,20 @@ log "$GREEN" "Configuring NSS"
 sed -E 's/(passwd|group): (.*)/\1: \2 kanidm/' -i /etc/nsswitch.conf
 
 log "$GREEN" "Configuring sshd"
-
-cat << EOT > /etc/ssh/sshd_config
+# Starting with 0.10.+ enable pre-shipped snippet
+if dpkg --compare-versions "$(kanidm-unix version | awk '{ print $2 }')" ge "1.10.0"; then
+  sed -i -E 's/^#(PubkeyAuthentication|UsePAM|AuthorizedKeysCommand|AuthorizedKeysCommandUser)/\1/' \
+    /etc/ssh/sshd_config.d/10-kanidm.conf || debug
+  echo 'LogLevel DEBUG1' >> /etc/ssh/sshd_config.d/00-debug.conf
+else
+  cat << EOT > /etc/ssh/sshd_config
 PubkeyAuthentication yes
 UsePAM yes
 AuthorizedKeysCommand /usr/sbin/kanidm_ssh_authorizedkeys %u
 AuthorizedKeysCommandUser nobody
 LogLevel DEBUG1
 EOT
+fi
 systemctl restart ssh.service || debug
 
 ## All done with setup, run tests

--- a/updatecli.d/default.yaml
+++ b/updatecli.d/default.yaml
@@ -1,0 +1,8 @@
+name: "github action updates"
+
+autodiscovery:
+  crawlers:
+    github/action:
+      spec:
+        digest: true
+        rootdir: ".github"


### PR DESCRIPTION
### Main highlights
- Release of 1.10.2 & 1.9.4 which are both security patch versions rated critical.
- Adds support for Ubuntu 26.04 Resolute Raccoon
- Fixes #43, the (deactivated) SSH config fragment is included in the 1.10.1 kanidm-unixd package.
- The full test suite was run on 1.10.1 & 1.9.3, but 1.10.2 & 1.9.4 were tested for only latest stable for the sake of expediency. Given the minor differences between the releases this is expected to be Fine.

### Other less interesting changes
- CI action updates with pinning to known good versions, and a manual process for updating the pins in a thoughtful manner. We release inoften enough that manual wins over automatic.
- Fixes #47 by ripping out compile caching. Due to heavy concurrency on incompatible platforms we fill up the cache immediately and only get a hit rate of 10-20% which does not justify the overhead. In practical testing time saved by caching and time consumed by caching is roughly in equilibrium and thus unnecessary complexity and attack surface.

### Test results

- Tests flagged as `ext` are against an external container run current stable kanidmd.
- Tests flagged as `self` are against an internal PPA installed kanidmd of the same version.
- Distro targets for `stable`: `trixie resolute bookworm noble jammy questing`
- Distro targets for `nightly`: `trixie resolute`

| TEST_ID                            | x86_64                  | aarch64                 |
| ---------------------------------- | ----------------------- | ----------------------- |
| testcase:1e:stable:ext             | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:1s:stable:self            | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2e:oldstable-upgrade:ext  | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2s:oldstable-upgrade:self | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:3e:nightly:ext            | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:4e:oldstable:ext          | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:4s:oldstable:self         | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |