### PR TITLE
feat: Publish 1.11 & refresh 1.10

### DIFF
--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -21,9 +21,9 @@ jobs:
           # Due to the limitations of this way of building the PPA, only the latest versions
           # are made available due to the lack of effective & reliable persistent storage.
           - name: stable
-            ref: v1.9.4
+            ref: v1.10.5
           - name: stable
-            ref: v1.10.4
+            ref: v1.11.0
         os:
           # We support stable, oldstable & latest interim releases.
           # - For Debian this means stable & oldstable

--- a/testing/test_payload.sh
+++ b/testing/test_payload.sh
@@ -188,7 +188,8 @@ if [[ "$IDM_URI" == "local" ]]; then
 
   log "$GREEN" "Starting kanidmd..."
   systemctl start kanidmd.service || debug
-  sleep 5s
+  log "$GREEN" "Waiting a bit for kanidmd to be ready..."
+  sleep 10s
   
   log "$GREEN" "Seeding kanidmd for posix login..."
   # The CLI behavior changes significantly with 1.9.0

--- a/testing/test_payload.sh
+++ b/testing/test_payload.sh
@@ -246,7 +246,12 @@ fi
 log "$GREEN" "Configuring kanidm-unixd..."
 if [[ "$LOCAL_IDM" == "true" ]]; then
   log "$GREEN" "Using local kanidmd, disabling verify_ca"
-  sed -e '/^verify_ca/s/true/false/' -i /etc/kanidm/config
+  if grep verify_ca /etc/kanidm/config >/dev/null; then
+    sed -e '/^verify_ca/s/true/false/' -i /etc/kanidm/config
+  else
+    # 1.11+ no longer include the line to modify
+    echo 'verify_ca = false' >> /etc/kanidm/config
+  fi
 fi
 # Set Kanidm level uri
 sed "s_# *uri.*_uri = \"${IDM_URI}\"_" -i /etc/kanidm/config


### PR DESCRIPTION
- Both new releases contain seucrity patches.
- This also drops 1.9 as per our support policy.

### Test results

- Tests flagged as `ext` are against an external container run current stable kanidmd.
- Tests flagged as `self` are against an internal PPA installed kanidmd of the same version.
- Distro targets for `stable`: `trixie resolute bookworm noble questing`

| TEST_ID                            | x86_64                  | aarch64                 |
| ---------------------------------- | ----------------------- | ----------------------- |
| testcase:1e:stable:ext             | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:1s:stable:self            | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2e:oldstable-upgrade:ext  | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2s:oldstable-upgrade:self | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:4e:oldstable:ext          | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:4s:oldstable:self         | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |