### PR TITLE
Release 1.11.1

### DIFF
--- a/.github/workflows/create-apt-repo.yml
+++ b/.github/workflows/create-apt-repo.yml
@@ -23,7 +23,7 @@ jobs:
           - name: stable
             ref: v1.10.5
           - name: stable
-            ref: v1.11.0
+            ref: v1.11.1
         os:
           # We support stable, oldstable & latest interim releases.
           # - For Debian this means stable & oldstable

--- a/testing/mise.toml
+++ b/testing/mise.toml
@@ -20,7 +20,7 @@ run = "scripts/run-all.sh"
 SUCCESS_WAIT = "false"
 
 [tasks.test_all]
-depends = ["testcase:*"]
+depends = ["testcase:**"]
 description = "Run the entire target list, pausing to allow testing every permutation"
 
 [tasks.test_shell]

--- a/testing/mise.toml
+++ b/testing/mise.toml
@@ -72,6 +72,10 @@ env = { CATEGORY = "stable", IDM_URI = "local" }
 extends = "testcase"
 env = { CATEGORY = "stable", KANIDM_VERSION = "{{env.OLDSTABLE_VERSION}}", KANIDM_UPGRADE = "true" }
 
+[tasks."testcase:2d:oldstable-upgrade:dirtyext"]
+extends = "testcase"
+env = { CATEGORY = "stable", KANIDM_VERSION = "{{env.OLDSTABLE_VERSION}}", KANIDM_UPGRADE = "dirty" }
+
 [tasks."testcase:2s:oldstable-upgrade:self"]
 extends = "testcase"
 env = { CATEGORY = "stable", IDM_URI = "local", KANIDM_VERSION = "{{env.OLDSTABLE_VERSION}}", KANIDM_UPGRADE = "true" }

--- a/testing/test_payload.sh
+++ b/testing/test_payload.sh
@@ -290,7 +290,14 @@ basic_test
 ## If given a newer version to upgrade to for testing oldstable -> stable migrations.
 if [[ "$KANIDM_UPGRADE" != "false" ]]; then
   log "$GREEN" "Performing upgrade to latest Kanidm packages"
-  apt-get install -y --only-upgrade '*kanidm*'
+  if [[ "$KANIDM_UPGRADE" == "dirty" ]]; then
+    log "$YELLOW" "Doing a dirty upgrade without specifying libnss & libpam"
+    apt-get install -y kanidm-unixd kanidm
+  else
+    apt-get install -y --only-upgrade '*kanidm*'
+  fi
+
+  # Retry basic_test after the upgrade
   basic_test
 fi
 


### PR DESCRIPTION
Primary change: Release Kanidm 1.11.1 which includes a security fix for kanidmd marked as Moderate

Additional:
   - This build includes the fix #52 for pinning internal library dependency versions which fixes #29 and prevents a nasty issue if you carelessly upgrade only kanidm-unixd without the libraries. Thanks to @mikaheli for the issue report and @yaleman for the fix.
   - Test case for ensuring said upgrade keeps working.
   - Minor testing update for newer Mise versions requiring explicit multi-level wildcarding in task dependencies.

### Test results

- Tests flagged as `ext` are against an external container run current stable kanidmd.
- Tests flagged as `self` are against an internal PPA installed kanidmd of the same version.
- Distro targets for `stable`: `trixie resolute bookworm noble questing`

| TEST_ID                                | x86_64                  | aarch64                 |
| -------------------------------------- | ----------------------- | ----------------------- |
| testcase:1e:stable:ext                 | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:1s:stable:self                | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2d:oldstable-upgrade:dirtyext | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2e:oldstable-upgrade:ext      | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:2s:oldstable-upgrade:self     | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:4e:oldstable:ext              | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |
| testcase:4s:oldstable:self             | <ul><li> [x] </li></ul> | <ul><li> [x] </li></ul> |